### PR TITLE
fix format strings in global_config

### DIFF
--- a/global_config.go
+++ b/global_config.go
@@ -39,7 +39,7 @@ func generateGlobalConfig(parsed *globalConfig) (*GlobalConfig, error) {
 	if parsed.Certificates.AdditionalCAs != nil {
 		for _, ca := range parsed.Certificates.AdditionalCAs {
 			if ok := sysCAs.AppendCertsFromPEM([]byte(ca)); !ok {
-				return nil, fmt.Errorf("failed to append certificate with content `%s` to CA pool")
+				return nil, fmt.Errorf("failed to append certificate with content `%s` to CA pool", ca)
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func generateGlobalConfig(parsed *globalConfig) (*GlobalConfig, error) {
 				return nil, err
 			}
 			if ok := sysCAs.AppendCertsFromPEM(data); !ok {
-				return nil, fmt.Errorf("failed to append certificate from file `%s` to CA pool")
+				return nil, fmt.Errorf("failed to append certificate from file `%s` to CA pool", caPath)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/otiai10/copy v1.0.1
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
 	github.com/pkg/errors v0.8.1 // indirect
-	github.com/pkg/sftp v1.10.0 // indirect
+	github.com/pkg/sftp v1.10.0
 	github.com/spf13/pflag v1.0.3
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 // indirect
+	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 )


### PR DESCRIPTION
I'm working on `make`ing this and ran into this, seems like a straightforward fix.

Before
```bash
[go2chef]$ go test
# github.com/facebookincubator/go2chef
./global_config.go:42: Errorf format %s reads arg #1, but call has 0 args
./global_config.go:54: Errorf format %s reads arg #1, but call has 0 args
```

After
```
[go2chef]$ git checkout fix_tests 
Switched to branch 'fix_tests'
[go2chef]$ go test
2019/08/26 20:28:53 captured panic: "ConfigSource dupe is already registered"
PASS
ok  	github.com/facebookincubator/go2chef	0.002s
```