### PR TITLE
Implementing go2chef.config_source.http so we can retrieve the

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 .idea/
 build/

--- a/bin/plugins.go
+++ b/bin/plugins.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/facebookincubator/go2chef/plugin/config/http"
 	_ "github.com/facebookincubator/go2chef/plugin/config/local"
 	_ "github.com/facebookincubator/go2chef/plugin/logger/stdlib"
 	_ "github.com/facebookincubator/go2chef/plugin/source/http"

--- a/plugin/config/http/http.go
+++ b/plugin/config/http/http.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/facebookincubator/go2chef"
+	"github.com/spf13/pflag"
+)
+
+// TypeName is the name of this configuration source
+const TypeName = "go2chef.config_source.http"
+
+// ConfigSource loads configuration data from JSON files from an http source
+type ConfigSource struct {
+	URL string
+}
+
+// InitFlags sets the command-line flags for http configuration sources
+func (c *ConfigSource) InitFlags(set *pflag.FlagSet) {
+	set.StringVar(&c.URL, "http-config", "", "http configuration path")
+}
+
+// ReadConfig loads the configuration file from http
+func (c *ConfigSource) ReadConfig() (map[string]interface{}, error) {
+	r, err := http.Get(c.URL)
+	if err != nil {
+		return nil, err
+	}
+	output := make(map[string]interface{})
+	if err := json.NewDecoder(r.Body).Decode(&output); err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+var _ go2chef.ConfigSource = &ConfigSource{}
+
+func init() {
+	if go2chef.AutoRegisterPlugins {
+		go2chef.RegisterConfigSource(TypeName, &ConfigSource{})
+	}
+}

--- a/plugin/config/http/http_test.go
+++ b/plugin/config/http/http_test.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigSource(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition", "attachment; filename=test.txt")
+		_, _ = fmt.Fprint(w, `{"key":"value"}`)
+	}))
+	defer ts.Close()
+
+	cs := &ConfigSource{URL: ts.URL}
+
+	if cr, err := cs.ReadConfig(); err != nil {
+		t.Fatalf("failed to read config: %s", err)
+	} else {
+		if v, ok := cr["key"]; ok {
+			if v != "value" {
+				t.Errorf("config[key] != value")
+			}
+		} else {
+			t.Errorf("config[key] does not exist")
+		}
+	}
+}


### PR DESCRIPTION
config.json file from a http source

tested on a macOS client with ./go2chef --config-source
go2chef.config_source.http --http-config https://url/config.json

% make test
go test ./...
ok  	github.com/facebookincubator/go2chef	(cached)
?   	github.com/facebookincubator/go2chef/bin	[no test files]
?   	github.com/facebookincubator/go2chef/cli	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/config/embed	(cached)
ok  	github.com/facebookincubator/go2chef/plugin/config/http	(cached)
ok  	github.com/facebookincubator/go2chef/plugin/config/local	(cached)
ok  	github.com/facebookincubator/go2chef/plugin/lib/certs	(cached)
?   	github.com/facebookincubator/go2chef/plugin/logger/stdlib	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/source/http	(cached)
?   	github.com/facebookincubator/go2chef/plugin/source/local	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/source/multi	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/bundle	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/command	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/group	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/darwin/pkg	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/linux/apt	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/linux/dnf	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/windows/msi	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/step/sanitycheck	(cached)
?   	github.com/facebookincubator/go2chef/scripts	[no test files]
?   	github.com/facebookincubator/go2chef/util	[no test files]
ok  	github.com/facebookincubator/go2chef/util/plugconf	(cached)
?   	github.com/facebookincubator/go2chef/util/temp	[no test files]
?   	github.com/facebookincubator/go2chef/util/testutil	[no test files]