### PR TITLE
Allow executable *.sh files to be directly executed, respecting shebangs

### DIFF
--- a/plugin/step/bundle/extcommand.go
+++ b/plugin/step/bundle/extcommand.go
@@ -58,6 +58,17 @@ func commandForPath(path string, ctx context.Context) *exec.Cmd {
 	case ".rb":
 		return exec.CommandContext(ctx, chefRuby(), path)
 	case ".sh":
+        fi, err := os.Lstat(path)
+        if err != nil {
+            return nil
+        }
+        mode := fi.Mode().Perm()
+        
+        // If the script is executable, execute it directly
+        if mode & 0111 == 0111 {
+            return exec.CommandContext(ctx, path)
+        }
+
 		return exec.CommandContext(ctx, "sh", path)
 	case ".bash":
 		return exec.CommandContext(ctx, "bash", path)


### PR DESCRIPTION
Make it so that if an *.sh file is provided, it will check if it's executable. This will fix the bug where a *.sh script may declare that it should use /bin/bash via a shebang, but because that doesn't get respected the bash features break go2chef.