### PR TITLE
use built-in zip package for zipping files in http testutil

### DIFF
--- a/plugin/step/sanitycheck/root_test.go
+++ b/plugin/step/sanitycheck/root_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package sanitycheck
 
 /*


### PR DESCRIPTION
`zip` is not an available executable on Windows and this leads to a test failure. 

Fortunately there is a go package built for this, so rather than use the `cmd` package to zip a file this leverages the `archive/zip` package to construct a zip and serve it at test time.

## Linux
```bash
$ make test
go test ./...
ok  	github.com/facebookincubator/go2chef	0.016s
?   	github.com/facebookincubator/go2chef/bin	[no test files]
?   	github.com/facebookincubator/go2chef/cli	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/config/embed	0.063s
ok  	github.com/facebookincubator/go2chef/plugin/config/http	0.005s
ok  	github.com/facebookincubator/go2chef/plugin/config/local	0.028s
ok  	github.com/facebookincubator/go2chef/plugin/lib/certs	0.064s
?   	github.com/facebookincubator/go2chef/plugin/logger/stdlib	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/source/http	0.031s
?   	github.com/facebookincubator/go2chef/plugin/source/local	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/source/multi	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/bundle	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/command	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/depnotify	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/group	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/darwin/pkg	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/linux/apt	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/linux/dnf	[no test files]
?   	github.com/facebookincubator/go2chef/plugin/step/install/windows/msi	[no test files]
ok  	github.com/facebookincubator/go2chef/plugin/step/sanitycheck	0.016s
?   	github.com/facebookincubator/go2chef/scripts	[no test files]
?   	github.com/facebookincubator/go2chef/util	[no test files]
ok  	github.com/facebookincubator/go2chef/util/plugconf	0.003s
?   	github.com/facebookincubator/go2chef/util/temp	[no test files]
?   	github.com/facebookincubator/go2chef/util/testutil	[no test files]
```

## Windows
```powershell
PS C:\go2chef> go test ./...
ok      github.com/facebookincubator/go2chef    (cached)
?       github.com/facebookincubator/go2chef/bin        [no test files]
?       github.com/facebookincubator/go2chef/cli        [no test files]
ok      github.com/facebookincubator/go2chef/plugin/config/embed        (cached)
ok      github.com/facebookincubator/go2chef/plugin/config/http (cached)
ok      github.com/facebookincubator/go2chef/plugin/config/local        (cached)
ok      github.com/facebookincubator/go2chef/plugin/lib/certs   (cached)
?       github.com/facebookincubator/go2chef/plugin/logger/stdlib       [no test files]
ok      github.com/facebookincubator/go2chef/plugin/source/http 2.723s
?       github.com/facebookincubator/go2chef/plugin/source/local        [no test files]
?       github.com/facebookincubator/go2chef/plugin/source/multi        [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/bundle [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/command        [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/depnotify      [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/group  [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/install/darwin/pkg     [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/install/linux/apt      [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/install/linux/dnf      [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/install/windows/msi    [no test files]
?       github.com/facebookincubator/go2chef/plugin/step/sanitycheck    [no test files]
?       github.com/facebookincubator/go2chef/scripts    [no test files]
?       github.com/facebookincubator/go2chef/util       [no test files]
ok      github.com/facebookincubator/go2chef/util/plugconf      (cached)
?       github.com/facebookincubator/go2chef/util/temp  [no test files]
?       github.com/facebookincubator/go2chef/util/testutil      [no test files]
```

`root_test.go` also does POSIXy things that cause a test failure on Windows, so I've added a build tag so the tests will pass for now.