### PR TITLE
support msi exit codes and cleanup log output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2
+	golang.org/x/text v0.3.0
 )


### PR DESCRIPTION
This addresses #26 to add acceptable user-specified MSI exit codes. 

Also, the installation logs are encoded in UTF16 which has the effect of having null characters between what would otherwise look like single characters. To make the console output look a bit cleaner this will convert the encoding to UTF8 so it is displayed properly
```
...
GO2CHEF 2020/03/11 16:44:54 DEBUG: C:/Users/dansedlacek/github/go2chef/plugin/source/http/http.go:161::http: direct download to C:\Users\DANSED~1\AppData\Local\Temp\go2chef-src-http-191889490, rename to C:\Users\DANSED~1\AppData\Local\Temp\go2chef-install187499775\chef-client-15.8.23-1-x64.msi
GO2CHEF 2020/03/11 16:44:54 EVENT: HTTP_DOWNLOAD_COMPLETE in go2chef.source.http - https://cpespace.thefacebook.com/chef/chef/chef-client-15.8.23-1-x64.msi
GO2CHEF 2020/03/11 16:44:54 ERROR: C:/Users/dansedlacek/github/go2chef/plugin/step/install/windows/msi/msi_windows.go:137::MSIEXEC exited with code 1603
GO2CHEF 2020/03/11 16:44:54 ERROR: C:/Users/dansedlacek/github/go2chef/plugin/step/install/windows/msi/msi_windows.go:154::MSIEXEC logs: === Verbose logging started: 3/11/2020  16:44:54  Build type: SHIP UNICODE 5.00.10011.00  Calling process: C:\windows\system32\msiexec.exe ===
MSI (c) (4C:D4) [16:44:54:463]: Resetting cached policy values
MSI (c) (4C:D4) [16:44:54:463]: Machine policy value 'Debug' is 0
MSI (c) (4C:D4) [16:44:54:463]: ******* RunEngine:                                                                                 ******* Product: C:\Users\DANSED~1\AppData\Local\Temp\go2chef-install187499775\chef-client-15.8.23-1-x64.msi            ******* Action:                                                                                                         ******* CommandLine: **********
MSI (c) (4C:D4) [16:44:54:463]: Client-side and UI is none or basic: Running entire install on the server.
MSI (c) (4C:D4) [16:44:54:463]: Grabbed execution mutex.                                                                                                          
....
```