### PR TITLE
Adding renaming fields to map step names to config name

### DIFF
--- a/plugin/step/command/command.go
+++ b/plugin/step/command/command.go
@@ -22,7 +22,7 @@ const TypeName = "go2chef.step.command"
 
 // Step implements a command execution step plugin
 type Step struct {
-	SName          string
+	SName          string `mapstructure:"name"`
 	Command        []string `mapstructure:"command"`
 	Env            map[string]string
 	TimeoutSeconds int      `mapstructure:"timeout_seconds"`

--- a/plugin/step/depnotify/depnotify.go
+++ b/plugin/step/depnotify/depnotify.go
@@ -16,7 +16,7 @@ const TypeName = "go2chef.step.depnotify"
 
 // Step implements a depnotify execution step plugin
 type Step struct {
-	SName   string
+	SName   string `mapstructure:"name"`
 	Status  bool
 	Message string
 	logger  go2chef.Logger

--- a/plugin/step/group/group.go
+++ b/plugin/step/group/group.go
@@ -22,7 +22,7 @@ const TypeName = "go2chef.step.group"
 // steps sequentially. If you're doing a bunch of steps you
 // probably want to use a `step_group` for it.
 type StepGroup struct {
-	GroupName string
+	GroupName string `mapstructure:"name"`
 	logger    go2chef.Logger
 	Steps     []go2chef.Step
 }


### PR DESCRIPTION
While trying to add more logging output,  I noticed some steps had an empty name.   Traced the issue down to some steps not having a mapstructure renaming field. 

Output before:
```
 &command.Step{SName:"", Command:[]string{"sleep", "2"}, Env:map[string]string{}, TimeoutSeconds:0, PassthroughEnv:[]string(nil), source:go2chef.Source(nil), logger:(*go2chef.MultiLogger)(0xc00022dad0), downloadPath:""}
```

After:
```
 &command.Step{SName:"Sleep 2 seconds", Command:[]string{"sleep", "2"}, Env:map[string]string{}, TimeoutSeconds:0, PassthroughEnv:[]string(nil), source:go2chef.Source(nil), logger:(*go2chef.MultiLogger)(0xc0001b2390), downloadPath:""}
```