### PR TITLE
Add extra logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,12 +9,30 @@ import (
 	"strings"
 )
 
+type ExtraLoggingFields struct {
+	StepName    string
+	StepType    string
+	StepCount   int
+	ElapsedTime int
+}
+
 // Event provides a more structured way to log information from
 // go2chef plugins.
 type Event struct {
-	Event     string
-	Component string
-	Message   string
+	Event       string
+	Component   string
+	Message     string
+	ExtraFields *ExtraLoggingFields
+}
+
+// NewEvent returns a new event using the provided parameters
+func NewEventWithExtraFields(event, component, message string, extrafields *ExtraLoggingFields) *Event {
+	return &Event{
+		Event:       event,
+		Component:   component,
+		Message:     message,
+		ExtraFields: extrafields,
+	}
 }
 
 // NewEvent returns a new event using the provided parameters


### PR DESCRIPTION
This change adds elapsed time to stdout logging for each step and cumulative elapsed run times.  It also adds the step name and step type to the logging message. 

Lastly,  Event struct has extra fields that can be used by other logging plugin to log  elapsed run times and other important metrics to understand go2chef runs health.  (I plan on having an internal logging plugin that will consume these extra fields) 

Idk why the spacing is wrong on github as in vscode, the code is alined correctly.  

Testing:
```
$ go run ./bin --local-config config.json
GO2CHEF 2020/04/03 11:23:03 loading config from source go2chef.config_source.local
GO2CHEF 2020/04/03 11:23:03 EVENT: LOGGING_INITIALIZED in go2chef.cli -
GO2CHEF 2020/04/03 11:23:03 EVENT: STEP_0_START noop:'noop' in go2chef.cli -
GO2CHEF 2020/04/03 11:23:03 INFO: /Users/gbatye/Documents/GitHub/go2chef/examples/plugins/noop/noop.go:40::noop noop: Download() called
GO2CHEF 2020/04/03 11:23:03 INFO: /Users/gbatye/Documents/GitHub/go2chef/examples/plugins/noop/noop.go:48::noop noop: Execute() called
GO2CHEF 2020/04/03 11:23:03 EVENT: STEP_0_COMPLETE noop:'noop' in go2chef.cli - completed successfully in 0 second(s)
GO2CHEF 2020/04/03 11:23:03 EVENT: ALL_STEPS_COMPLETE in go2chef.cli - 1 step(s) completed successfully in 0 second(s)
2020/04/03 11:23:03 temp dirs cleanup completed
```

```
[11:27AM] ~/Documents/GitHub/go2chef/build/darwin/amd64  ± Add_extra_logging ● 
$ ./go2chef --local-config config.json

          ___    _         __
 __ _ ___|_  )__| |_  ___ / _|
/ _` / _ \/ // _| ' \/ -_)  _|
\__, \___/___\__|_||_\___|_|
|___/

GO2CHEF 2020/04/03 11:27:25 loading config from source go2chef.config_source.local
GO2CHEF 2020/04/03 11:27:25 EVENT: LOGGING_INITIALIZED in go2chef.cli -
GO2CHEF 2020/04/03 11:27:25 EVENT: STEP_0_START go2chef.step.command:'' in go2chef.cli -
GO2CHEF 2020/04/03 11:27:27 EVENT: STEP_0_COMPLETE go2chef.step.command:'' in go2chef.cli - completed successfully in 2 second(s)
GO2CHEF 2020/04/03 11:27:27 EVENT: STEP_1_START go2chef.step.command:'' in go2chef.cli -
GO2CHEF 2020/04/03 11:27:28 EVENT: STEP_1_COMPLETE go2chef.step.command:'' in go2chef.cli - completed successfully in 1 second(s)
GO2CHEF 2020/04/03 11:27:28 EVENT: ALL_STEPS_COMPLETE in go2chef.cli - 2 step(s) completed successfully in 3 second(s)
2020/04/03 11:27:28 temp dirs cleanup completed
```

