### PR TITLE
Add hashing support to the http source type

### DIFF
--- a/examples/config_install_pkg.json
+++ b/examples/config_install_pkg.json
@@ -15,7 +15,8 @@
       "is_dmg": true,
       "source": {
         "type": "go2chef.source.http",
-        "url": "https://packages.chef.io/files/stable/chef/15.2.20/mac_os_x/10.14/chef-15.2.20-1.dmg"
+        "url": "https://packages.chef.io/files/stable/chef/16.1.16/mac_os_x/10.15/chef-16.1.16-1.dmg",
+        "sha256": "95e62c5824e361b12a30981cab677da1010d2f05b7e3f0c538d885881a4daf4a"
       }
     }
   ]

--- a/util/hashfile/hashfile.go
+++ b/util/hashfile/hashfile.go
@@ -1,0 +1,26 @@
+package hashfile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// SHA256 returns a sha256 hash of the file at the given filepath.
+func SHA256(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	hString := hex.EncodeToString(h.Sum(nil))
+
+	return hString, nil
+}


### PR DESCRIPTION
This adds support for sha256 hashes to the http source type. 

If no sha256 is provided, this behaves identically to the current code.

If you want any tests around this, happy to do so.