### PR TITLE
Allow downgrading with RPM plugin

### DIFF
--- a/plugin/step/install/linux/dnf/dnf.go
+++ b/plugin/step/install/linux/dnf/dnf.go
@@ -251,7 +251,7 @@ func (s *Step) installChefRPM(installPackage string) error {
 	instCtx, instCtxCancel := context.WithTimeout(context.Background(), time.Duration(s.InstallTimeoutSeconds)*time.Second)
 	defer instCtxCancel()
 
-	cmd := exec.CommandContext(instCtx, s.RPMBinary, "-Uvh", installPackage)
+	cmd := exec.CommandContext(instCtx, s.RPMBinary, "-Uvh", "--oldpackage", installPackage)
 	cmd.Stdin = nil
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This fixes #35, where unlike the `dnf` plugin the `rpm` plugin does not allow downgrading the package. Allowing a downgrade is incredibly useful as it ensures Go2Chef can be used to remediate systems as well (i.e. the version of Chef is a "known good" version, and we can bring systems back in line with that).

Tested this and the new behavior works as expected:
https://gist.github.com/steelcowboy/b0283f7b356525f1070f43fd8fcdc582