### PR TITLE
fix unarchiving s3 files

### DIFF
--- a/plugin/source/s3/s3.go
+++ b/plugin/source/s3/s3.go
@@ -110,13 +110,13 @@ func (s *Source) DownloadToPath(dlPath string) error {
 	s.logger.Debugf(0, "downloaded %d bytes for %s:%s from S3", n, s.Bucket, s.Key)
 	tmpfh.Close()
 
-	if !s.Archive {
-		if err := os.Rename(tmpfh.Name(), outfn); err != nil {
-			s.logger.Errorf("failed to relocate", outfn, dlPath)
-			return err
-		}
-		s.logger.Debugf(0, "relocated downloaded file from %s to %s", tmpfh.Name(), outfn)
-	} else {
+	if err := os.Rename(tmpfh.Name(), outfn); err != nil {
+		s.logger.Errorf("failed to relocate", outfn, dlPath)
+		return err
+	}
+
+	s.logger.Debugf(0, "relocated downloaded file from %s to %s", tmpfh.Name(), outfn)
+	if s.Archive {
 		if err := archiver.Unarchive(outfn, dlPath); err != nil {
 			s.logger.Errorf("failed to unarchive %s to dir %s", outfn, dlPath)
 			return err


### PR DESCRIPTION
When trying to retrieve an archive from S3 there is a problem when it hits the `else` branch in that the file hasn't been renamed so it is unable to be extracted.

My intuition here is that we've retrieved the file and want to rename it regardless of if it is an archive or not. With this change I am able to retrieve and extract the blob:
```
./go2chef.exe --local-config ../test.json --preserve-temp

          ___    _         __
 __ _ ___|_  )__| |_  ___ / _|
/ _` / _ \/ // _| ' \/ -_)  _|
\__, \___/___\__|_||_\___|_|
|___/

GO2CHEF 2020/09/01 15:58:59 loading config from source go2chef.config_source.local
GO2CHEF 2020/09/01 15:58:59 EVENT: LOGGING_INITIALIZED in go2chef.cli -
GO2CHEF 2020/09/01 15:58:59 EVENT: STEP_0_START go2chef.winsanitycheck:'windows checks' in go2chef.cli -
2020/09/01 15:58:59 executing sanity checks
2020/09/01 15:58:59 running sanity check msi_lock
GO2CHEF 2020/09/01 15:58:59 EVENT: STEP_0_COMPLETE go2chef.winsanitycheck:'windows checks' in go2chef.cli - completed successfully in 0 second(s)
GO2CHEF 2020/09/01 15:58:59 EVENT: STEP_1_START go2chef.step.bundle:'install chefctl' in go2chef.cli -
GO2CHEF 2020/09/01 15:58:59 DEBUG: C:/Users/svmastersamurai/github/go2chef/plugin/step/bundle/bundle.go:54::install chefctl: downloading bundle
GO2CHEF 2020/09/01 15:58:59 DEBUG: C:/Users/svmastersamurai/github/go2chef/plugin/source/s3/s3.go:72::copy directory C:\Users\DANSED~1\AppData\Local\Temp\go2chef-bundle370703043 is ready
GO2CHEF 2020/09/01 15:58:59 DEBUG: C:/Users/svmastersamurai/github/go2chef/plugin/source/s3/s3.go:110::downloaded 65868 bytes for fbcpe-go2chef:windows/chefctl.tar.gz from S3
GO2CHEF 2020/09/01 15:58:59 DEBUG: C:/Users/svmastersamurai/github/go2chef/plugin/source/s3/s3.go:118::relocated downloaded file from C:\Users\DANSED~1\AppData\Local\Temp\430039366 to C:\Users\DANSED~1\AppData\Local\Temp\go2chef-bundle370703043\chefctl.tar.gz
GO2CHEF 2020/09/01 15:58:59 DEBUG: C:/Users/svmastersamurai/github/go2chef/plugin/step/bundle/bundle.go:64::install chefctl: downloaded bundle to C:\Users\DANSED~1\AppData\Local\Temp\go2chef-bundle370703043
GO2CHEF 2020/09/01 15:59:00 EVENT: STEP_1_COMPLETE go2chef.step.bundle:'install chefctl' in go2chef.cli - completed successfully in 1 second(s)
GO2CHEF 2020/09/01 15:59:00 EVENT: ALL_STEPS_COMPLETE in go2chef.cli - 2 step(s) completed successfully in 1 second(s)
2020/09/01 15:59:00 preserving temp path C:\Users\DANSED~1\AppData\Local\Temp\go2chef-bundle370703043
2020/09/01 15:59:00 temp dirs cleanup completed
PS C:\Users\svmastersamurai\github\go2chef\bin> dir C:\Users\SVMAST~1\AppData\Local\Temp\go2chef-bundle370703043 | select -first 2


    Directory: C:\Users\svmastersamurai\AppData\Local\Temp\go2chef-bundle370703043


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----          9/1/2020   3:58 PM            317 bundle.ps1
-a----          9/1/2020   3:58 PM            283 chefctl-config.rb
```

I have also confirmed that retrieving a flat file still works as expected.