### PR TITLE
handle msi in uninstalled state better

### DIFF
--- a/plugin/source/http/http.go
+++ b/plugin/source/http/http.go
@@ -147,8 +147,8 @@ func (s *Source) DownloadToPath(dlPath string) (err error) {
 			return err
 		}
 
-		s.logger.Debugf(1, "Calcluated hash is %s: ", fileHash)
-		s.logger.Debugf(1, "Provided hash: %s", s.SHA256)
+		s.logger.Debugf(1, "%s: calculated hash %s", s.Name(), fileHash)
+		s.logger.Debugf(1, "%s: provided hash %s", s.Name(), s.SHA256)
 		// If the hash doesn't match what is provided, return an error.
 		if fileHash != s.SHA256 {
 			return errors.New("sha256 hashes do not match")

--- a/plugin/step/winsanitycheck/sanity_check.go
+++ b/plugin/step/winsanitycheck/sanity_check.go
@@ -7,7 +7,6 @@ package winsanitycheck
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/facebookincubator/go2chef"
 	"github.com/mitchellh/mapstructure"
@@ -41,7 +40,7 @@ func (s *SanityCheck) Download() error { return nil }
 
 // Execute performs the sanity checks
 func (s *SanityCheck) Execute() error {
-	log.Printf("executing sanity checks")
+	go2chef.GetGlobalLogger().Debugf(1, "executing sanity checks")
 	checks := make(map[string]CheckFn)
 	for _, en := range s.Enabled {
 		if sc, ok := sanityCheckRegistry[en]; ok {
@@ -51,7 +50,7 @@ func (s *SanityCheck) Execute() error {
 		}
 	}
 	for n, c := range checks {
-		log.Printf("running sanity check %s", n)
+		go2chef.GetGlobalLogger().Debugf(1, "running sanity check %s", n)
 		fix, err := c(s)
 		if err == ErrSanityCheckNeedsFix && fix != nil {
 			if err := fix(s); err != nil {


### PR DESCRIPTION
This will tweak the behavior of the msi step to handle cases when Chef is uninstalled and the `uninstall` and `rename_folder` sub-steps are  enabled.

Fixed a couple spots in logging to be more consistent.

Minor code cleanup with introduction of new method for shell outs.