### PR TITLE
fix s3 file step across filesystems

### DIFF
--- a/plugin/source/s3/s3.go
+++ b/plugin/source/s3/s3.go
@@ -74,10 +74,10 @@ func (s *Source) DownloadToPath(dlPath string) error {
 	/*
 		AWS download:
 		- build credentials and init session
-		- create temporary file
+		- create temporary file in dlPath
 		- download s3 data to temp file
-		- if !archive, rename into output path
-		- else decompress archive to output path
+		- rename temporary file to output file
+		- if archive: decompress to dlPath
 	*/
 	cfg := aws.NewConfig().WithRegion(s.Region)
 	if s.Credentials.AccessKeyID != "" && s.Credentials.SecretAccessKey != "" {
@@ -93,7 +93,8 @@ func (s *Source) DownloadToPath(dlPath string) error {
 	dl := s3manager.NewDownloader(sess)
 
 	outfn := filepath.Join(dlPath, filepath.Base(s.Key))
-	tmpfh, err := ioutil.TempFile("", "")
+	// create tmpfile in dlPath to store S3 contents before Renaming to final location
+	tmpfh, err := ioutil.TempFile(dlPath, "")
 	if err != nil {
 		s.logger.Debugf(0, "failed to create output file for S3 download: %s", err)
 		return err


### PR DESCRIPTION
When using go2chef.step.file from S3 go2chef will fail at the
os.Rename() call if /tmp is a different filesystem than the destination
of the download as golang's os.Rename calls syscall Renameat which in
turn calls link which does not support linking files across mount
point.

The above results in an `invalid cross-device link` error.  This for example
will always happen on hosts where systemd is configured to mount /tmp as
tmpfs.

Instead of always creating our ioutil.TempFile() in the default
location, create it in the destination path instead.  This keeps
the same atomic-ness as the original implementation but ensures that the
source and destinations for os.Rename will always target the same mount
point.