### PR TITLE
Build for Darwin ARM devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ linux32:
 darwin:
 	GOOS=darwin GOARCH=amd64 scripts/build.sh
 
+.PHONY: darwinARM
+darwinARM:
+	GOOS=darwin GOARCH=arm64 scripts/build.sh
+
 .PHONY: windows
 windows:
 	GOOS=windows GOARCH=amd64 scripts/build.sh


### PR DESCRIPTION
Now that Apple has largely discontinued their x86 macOS devices, it's worth adding a build target for Darwin on ARM.
It might be worth providing instructions on how to build a fat universal binary for folks running go2chef as part of a bootstrapping workflow before Rosetta is installed:
`lipo build/darwin/arm64/go2chef build/darwin/amd64/go2chef -create -output universal_go2chef`