### PR TITLE
bug fix "output_filename" config option for http Source

### DIFF
--- a/plugin/source/http/http.go
+++ b/plugin/source/http/http.go
@@ -128,8 +128,10 @@ func (s *Source) DownloadToPath(dlPath string) (err error) {
 	  - If not, check if the Content-Disposition has a download filename set and use that if so
 	*/
 	outputFilename := path.Base(req.URL.Path)
+
+	s.logger.Debugf(1, "Configured OutputFilename: '%s'",  s.OutputFilename)
 	if s.OutputFilename != "" {
-		outputFilename = dlPath
+		outputFilename = s.OutputFilename
 	} else {
 		_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition"))
 		if err == nil {
@@ -139,6 +141,7 @@ func (s *Source) DownloadToPath(dlPath string) (err error) {
 		}
 	}
 	outputPath := filepath.Join(dlPath, outputFilename)
+	s.logger.Debugf(1, "Final outputPath: '%s'", outputPath)
 
 	if s.SHA256 != "" {
 		s.logger.Debugf(1, "%s: sha256 was provided, validating %s", s.Name(), outputPath)


### PR DESCRIPTION
When "output_filename" config is specified, the bug is that we throw away the provided "output_filename" and double up the path instead. As a result the rename destination would look like `/tmp/go2chef-bundle4225527918/tmp/go2chef-bundle4225527918` and fail in the next operation with
>"STEP_1_FAILURE go2chef.step.bundle:'<step_name>' in go2chef.cli - file does not exist". This bug triggered for RPMs and tar.gz archives.