### PR TITLE
Replace os.Rename() with file copy/removal to allow cross mounts/filesystems/drives operations

### DIFF
--- a/plugin/source/http/http.go
+++ b/plugin/source/http/http.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/facebookincubator/go2chef/util/hashfile"
 	"github.com/facebookincubator/go2chef/util/temp"
+	"github.com/facebookincubator/go2chef/util"
 
 	"github.com/facebookincubator/go2chef"
 	"github.com/mholt/archiver/v3"
@@ -166,7 +167,7 @@ func (s *Source) DownloadToPath(dlPath string) (err error) {
 		_ = tmpfile.Close()
 		s.logger.Debugf(1, "%s: archive mode enabled, extracting %s to %s", s.Name(), tmpfile.Name(), dlPath)
 		extFilename := filepath.Join(filepath.Dir(tmpfile.Name()), outputFilename)
-		if err := os.Rename(tmpfile.Name(), extFilename); err != nil {
+		if err := util.MoveFile(tmpfile.Name(), extFilename); err != nil {
 			s.logger.Errorf("failed to relocate output")
 			return err
 		}
@@ -181,7 +182,7 @@ func (s *Source) DownloadToPath(dlPath string) (err error) {
 		*/
 		s.logger.Debugf(1, "%s: direct download to %s, rename to %s", s.Name(), tmpfile.Name(), outputPath)
 		_ = tmpfile.Close()
-		return os.Rename(tmpfile.Name(), outputPath)
+		return util.MoveFile(tmpfile.Name(), outputPath)
 	}
 	return nil
 }

--- a/plugin/source/s3/s3.go
+++ b/plugin/source/s3/s3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/facebookincubator/go2chef"
 	"github.com/mholt/archiver/v3"
 	"github.com/mitchellh/mapstructure"
+	"github.com/facebookincubator/go2chef/util"
 )
 
 // TypeName is the name of this source plugin
@@ -111,7 +112,7 @@ func (s *Source) DownloadToPath(dlPath string) error {
 	s.logger.Debugf(0, "downloaded %d bytes for %s:%s from S3", n, s.Bucket, s.Key)
 	tmpfh.Close()
 
-	if err := os.Rename(tmpfh.Name(), outfn); err != nil {
+	if err := util.MoveFile(tmpfh.Name(), outfn); err != nil {
 		s.logger.Errorf("failed to relocate", outfn, dlPath)
 		return err
 	}

--- a/util/fs.go
+++ b/util/fs.go
@@ -47,3 +47,23 @@ func PathExists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
 }
+
+// MoveFile moves file
+func MoveFile(oldpath, newpath string) error {
+	r, err := os.Open(oldpath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	w, err := os.Create(newpath)
+	if err != nil {
+		return err
+	}
+	if _, err = w.ReadFrom(r); err != nil {
+		return err
+	}
+	if w.Close() != nil {
+		return err
+	}
+	return os.Remove(oldpath)
+}


### PR DESCRIPTION
When /tmp and destination are on different mountpoints, os.Rename() can't do it because of underlying system call limitations:
```
$ man 2 rename | grep -A2 EXDEV
       EXDEV  oldpath  and  newpath are not on the same mounted filesystem.  (Linux permits a filesystem to be mounted at multiple points, but rename() does not work across different mount points, even if the same filesystem is mounted on both.)
```
Error that we see is:
```
rename /tmp/go2chef-src-http-896405783 /etc/chef/chef_servers.json: invalid cross-device link
```
In order to overcome this limitation, we want to replace file rename with basic copy/delete operations.

Manually tested new binary on test server to ensure correct file operations.
```
GO2CHEF 2023/05/30 14:54:32 loading config from source go2chef.config_source.local
GO2CHEF 2023/05/30 14:54:32 EVENT: LOGGING_INITIALIZED in go2chef.cli -
GO2CHEF 2023/05/30 14:54:32 EVENT: STEP_0_START go2chef.step.install.linux.dnf:'install chef client' in go2chef.cli -
GO2CHEF 2023/05/30 14:54:32 INFO: /home/alexeys/oss/go2chef/plugin/step/install/linux/dnf/dnf.go:204::Package is already installed: chef-17.9.52-1.el7.x86_64, requested ^chef-17.9.52-1.el7.*
GO2CHEF 2023/05/30 14:54:32 INFO: /home/alexeys/oss/go2chef/plugin/step/install/linux/dnf/dnf.go:204::Package is already installed: chef-17.9.52-1.el7.x86_64, requested ^chef-17.9.52-1.el7.*
GO2CHEF 2023/05/30 14:54:32 INFO: /home/alexeys/oss/go2chef/plugin/step/install/linux/dnf/dnf.go:132::chef specified is already installed, not reinstalling
GO2CHEF 2023/05/30 14:54:32 EVENT: STEP_0_COMPLETE go2chef.step.install.linux.dnf:'install chef client' in go2chef.cli - completed successfully in 0 second(s)
GO2CHEF 2023/05/30 14:54:32 EVENT: STEP_1_START go2chef.step.bundle:'fetch bundle' in go2chef.cli -
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/step/bundle/bundle.go:54::fetch bundle: downloading bundle
GO2CHEF 2023/05/30 14:54:32 EVENT: HTTP_DOWNLOAD_STARTED in go2chef.source.http - https://package.thefacebook.com/go2chef/chefctl.tgz
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/source/http/http.go:95::fetch bundle-source: 1
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/source/http/http.go:108::fetch bundle-source: HTTP GET https://package.thefacebook.com/go2chef/chefctl.tgz => 200 OK
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/source/http/http.go:133::Configured OutputFilename: ''
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/source/http/http.go:145::Final outputPath: '/tmp/go2chef-bundle259860061/chefctl.tgz'
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/source/http/http.go:168::fetch bundle-source: archive mode enabled, extracting /tmp/go2chef-src-http-1612631937 to /tmp/go2chef-bundle259860061
GO2CHEF 2023/05/30 14:54:32 EVENT: HTTP_DOWNLOAD_COMPLETE in go2chef.source.http - https://package.thefacebook.com/go2chef/chefctl.tgz
GO2CHEF 2023/05/30 14:54:32 DEBUG: /home/alexeys/oss/go2chef/plugin/step/bundle/bundle.go:64::fetch bundle: downloaded bundle to /tmp/go2chef-bundle259860061
```


Tags: