### PR TITLE
[github] Use actions/checkout@v3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
         go-version: 1.16
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Test on Windows
       if: runner.os == 'windows'
       run: go test ./...


### PR DESCRIPTION
Trivial fix for https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/